### PR TITLE
Optimize AppBlocker cache refreshing and save battery on unlock

### DIFF
--- a/app/src/main/java/com/neubofy/reality/services/AppBlockerService.kt
+++ b/app/src/main/java/com/neubofy/reality/services/AppBlockerService.kt
@@ -134,10 +134,6 @@ class AppBlockerService : BaseBlockingService() {
                 Intent.ACTION_USER_PRESENT -> {
                     isScreenOn = true
                     
-                    // Full settings refresh on unlock - ensures schedules are loaded and evaluated immediately
-                    refreshSettings()
-                    com.neubofy.reality.utils.SmartScheduleManager.scheduleNextTransition(applicationContext)
-                    
                     // Resume checking if needed
                     if (browserWatchdog.isWebsiteBlockActive()) {
                          browserWatchdog.startBrowserCheckTimer()

--- a/app/src/main/java/com/neubofy/reality/services/TapasyaManager.kt
+++ b/app/src/main/java/com/neubofy/reality/services/TapasyaManager.kt
@@ -344,7 +344,7 @@ object TapasyaManager {
         data.isTapasyaTriggered = true
         prefs.saveFocusModeData(data)
         
-        ctx.sendBroadcast(Intent(AppBlockerService.INTENT_ACTION_REFRESH_FOCUS_MODE).apply {
+        ctx.sendBroadcast(android.content.Intent(com.neubofy.reality.services.AppBlockerService.INTENT_ACTION_REFRESH_FOCUS_MODE).apply {
             setPackage(ctx.packageName)
         })
     }
@@ -356,7 +356,7 @@ object TapasyaManager {
         data.isTapasyaTriggered = false
         prefs.saveFocusModeData(data)
         
-        ctx.sendBroadcast(Intent(AppBlockerService.INTENT_ACTION_REFRESH_FOCUS_MODE).apply {
+        ctx.sendBroadcast(android.content.Intent(com.neubofy.reality.services.AppBlockerService.INTENT_ACTION_REFRESH_FOCUS_MODE).apply {
             setPackage(ctx.packageName)
         })
     }

--- a/app/src/main/java/com/neubofy/reality/ui/activity/ReflectionSettingsActivity.kt
+++ b/app/src/main/java/com/neubofy/reality/ui/activity/ReflectionSettingsActivity.kt
@@ -353,6 +353,11 @@ class ReflectionSettingsActivity : BaseActivity() {
             binding.layoutViewLimit.visibility = View.VISIBLE
 
             Toast.makeText(this, "Screen time limit saved", Toast.LENGTH_SHORT).show()
+
+            // Notify blocker service immediately
+            val intent = android.content.Intent(com.neubofy.reality.services.AppBlockerService.INTENT_ACTION_REFRESH_FOCUS_MODE)
+            intent.setPackage(packageName)
+            sendBroadcast(intent)
         }
 
         // Setup switch_block_after_limit

--- a/app/src/main/java/com/neubofy/reality/ui/activity/ScheduleListActivity.kt
+++ b/app/src/main/java/com/neubofy/reality/ui/activity/ScheduleListActivity.kt
@@ -393,7 +393,7 @@ class ScheduleListActivity : BaseActivity() {
         lifecycleScope.launch(Dispatchers.IO) {
             val db = AppDatabase.getDatabase(applicationContext)
             db.calendarEventDao().deleteByEventId(event.eventId)
-            sendBroadcast(android.content.Intent(com.neubofy.reality.services.AppBlockerService.INTENT_ACTION_REFRESH_FOCUS_MODE))
+            sendBroadcast(android.content.Intent(com.neubofy.reality.services.AppBlockerService.INTENT_ACTION_REFRESH_FOCUS_MODE).apply { setPackage(packageName) })
             com.neubofy.reality.utils.SmartScheduleManager.scheduleNextTransition(this@ScheduleListActivity)
             withContext(Dispatchers.Main) { 
                 loadSchedules() 
@@ -514,7 +514,7 @@ class ScheduleListActivity : BaseActivity() {
                                 db.calendarEventDao().insertAll(listOf(newItem))
                                 com.neubofy.reality.utils.NotificationHelper.showInfoNotification(applicationContext, "Schedule Created", "Your productive session '${title}' has been scheduled.")
                             }
-                            sendBroadcast(android.content.Intent(com.neubofy.reality.services.AppBlockerService.INTENT_ACTION_REFRESH_FOCUS_MODE))
+                            sendBroadcast(android.content.Intent(com.neubofy.reality.services.AppBlockerService.INTENT_ACTION_REFRESH_FOCUS_MODE).apply { setPackage(packageName) })
                             com.neubofy.reality.utils.SmartScheduleManager.scheduleNextTransition(this@ScheduleListActivity)
                             withContext(Dispatchers.Main) {
                                 loadSchedules()

--- a/app/src/main/java/com/neubofy/reality/ui/activity/StrictModeActivity.kt
+++ b/app/src/main/java/com/neubofy/reality/ui/activity/StrictModeActivity.kt
@@ -688,7 +688,7 @@ class StrictModeActivity : BaseActivity() {
     private fun saveSettings() {
         prefsLoader.saveStrictModeData(strictData)
         // Optimization: Send single broadcast. Service handles both Strict Mode and Focus Mode updates with this.
-        sendBroadcast(Intent(AppBlockerService.INTENT_ACTION_REFRESH_FOCUS_MODE))
+        sendBroadcast(android.content.Intent(com.neubofy.reality.services.AppBlockerService.INTENT_ACTION_REFRESH_FOCUS_MODE).apply { setPackage(packageName) })
     }
     
     private fun hashPassword(password: String): String {

--- a/app/src/main/java/com/neubofy/reality/ui/fragments/AppLimitsFragment.kt
+++ b/app/src/main/java/com/neubofy/reality/ui/fragments/AppLimitsFragment.kt
@@ -339,7 +339,7 @@ class AppLimitsFragment : Fragment() {
                     }
                     
                     withContext(Dispatchers.Main) {
-                        context.sendBroadcast(Intent(AppBlockerService.INTENT_ACTION_REFRESH_FOCUS_MODE))
+                        context.sendBroadcast(android.content.Intent(com.neubofy.reality.services.AppBlockerService.INTENT_ACTION_REFRESH_FOCUS_MODE).apply { setPackage(context.packageName) })
                         loadLimits()
                     }
                 }
@@ -368,7 +368,7 @@ class AppLimitsFragment : Fragment() {
                     savedPreferencesLoader.saveUsageLimitData(usageData)
                     
                     withContext(Dispatchers.Main) {
-                        context.sendBroadcast(Intent(AppBlockerService.INTENT_ACTION_REFRESH_FOCUS_MODE))
+                        context.sendBroadcast(android.content.Intent(com.neubofy.reality.services.AppBlockerService.INTENT_ACTION_REFRESH_FOCUS_MODE).apply { setPackage(context.packageName) })
                         loadLimits()
                     }
                 }

--- a/app/src/main/java/com/neubofy/reality/ui/fragments/GroupsFragment.kt
+++ b/app/src/main/java/com/neubofy/reality/ui/fragments/GroupsFragment.kt
@@ -255,7 +255,7 @@ class GroupsFragment : Fragment() {
                     val db = AppDatabase.getDatabase(requireContext())
                     db.appGroupDao().insert(newGroup)
                     
-                    requireContext().sendBroadcast(Intent(AppBlockerService.INTENT_ACTION_REFRESH_FOCUS_MODE))
+                    requireContext().sendBroadcast(android.content.Intent(com.neubofy.reality.services.AppBlockerService.INTENT_ACTION_REFRESH_FOCUS_MODE).apply { setPackage(requireContext().packageName) })
                     loadGroups()
                 }
             }
@@ -295,7 +295,7 @@ class GroupsFragment : Fragment() {
         scope.launch(Dispatchers.IO) {
              val db = AppDatabase.getDatabase(requireContext())
              db.appGroupDao().delete(group)
-             requireContext().sendBroadcast(Intent(AppBlockerService.INTENT_ACTION_REFRESH_FOCUS_MODE))
+             requireContext().sendBroadcast(android.content.Intent(com.neubofy.reality.services.AppBlockerService.INTENT_ACTION_REFRESH_FOCUS_MODE).apply { setPackage(requireContext().packageName) })
              loadGroups()
         }
     }


### PR DESCRIPTION
Optimized `AppBlockerService.kt` by removing battery-draining block cache rebuilds triggered automatically on every screen unlock (`ACTION_USER_PRESENT`). Instead, ensuring that accurate and explicit broadcast triggers (`INTENT_ACTION_REFRESH_FOCUS_MODE`) with proper `setPackage()` attributes are dispatched directly from the UI when users actually modify blocker settings like app limits, groups, blocklists, and nightly screen limits. This provides a much snappier experience, fixes bugs where settings seemingly wouldn't apply, and saves battery.

---
*PR created automatically by Jules for task [14767297322492808139](https://jules.google.com/task/14767297322492808139) started by @pawanwashudev-official*