### PR TITLE
Fix: Unify 401 Unauthorized handling for Google Workspace APIs

### DIFF
--- a/app/src/main/java/com/neubofy/reality/google/GoogleAuthManager.kt
+++ b/app/src/main/java/com/neubofy/reality/google/GoogleAuthManager.kt
@@ -571,7 +571,12 @@ object GoogleAuthManager {
                                     TerminalLogger.log("GOOGLE AUTH: Auto-refresh failed: \${e.message}")
                                 }
                             }
-                            return super.handleResponse(request, response, supportsRetry)
+                            val handled = super.handleResponse(request, response, supportsRetry)
+                            if (!handled && response.statusCode == 401) {
+                                TerminalLogger.log("GOOGLE AUTH: Unauthorized (401) error encountered in Firebase session, triggering handleAuthFailure")
+                                handleAuthFailure(context)
+                            }
+                            return handled
                         }
                     }
                     credential.setAccessToken(accToken)
@@ -625,7 +630,22 @@ object GoogleAuthManager {
             }
         })
 
-        return builder.build()
+        val credential = object : Credential(builder) {
+            override fun handleResponse(
+                request: com.google.api.client.http.HttpRequest,
+                response: com.google.api.client.http.HttpResponse,
+                supportsRetry: Boolean
+            ): Boolean {
+                val handled = super.handleResponse(request, response, supportsRetry)
+                if (!handled && response.statusCode == 401) {
+                    TerminalLogger.log("GOOGLE AUTH: Unauthorized (401) error encountered in Workspace API, triggering handleAuthFailure")
+                    handleAuthFailure(context)
+                }
+                return handled
+            }
+        }
+
+        return credential
             .setAccessToken(accessToken)
             .setRefreshToken(refreshToken)
     }


### PR DESCRIPTION
Fix: Unify 401 Unauthorized handling for Google Workspace APIs

Previously, when a Google Workspace token expired and failed to auto-refresh, some parts of the app (like Google Drive, Docs, Sheets, and Tasks managers) would catch the resulting exception and fail silently, making the app appear "stuck".
This commit centralizes the error handling by overriding `handleResponse` on the `Credential` instances in `GoogleAuthManager.kt` (for both Firebase and Custom OAuth sessions). When a 401 response is not handled by the underlying refresh logic, it now explicitly calls `handleAuthFailure` to force a sign-out and prompt the user to re-authenticate, unifying the behavior across all Workspace integrations.

---
*PR created automatically by Jules for task [4080832658898631635](https://jules.google.com/task/4080832658898631635) started by @pawanwashudev-official*