### PR TITLE
Remove unused Google Docs scopes

### DIFF
--- a/app/src/main/java/com/neubofy/reality/ui/activity/ProfileActivity.kt
+++ b/app/src/main/java/com/neubofy/reality/ui/activity/ProfileActivity.kt
@@ -12,7 +12,6 @@ import coil.load
 import coil.transform.CircleCropTransformation
 import com.google.api.client.googleapis.extensions.android.gms.auth.UserRecoverableAuthIOException
 import com.google.api.services.calendar.CalendarScopes
-import com.google.api.services.docs.v1.DocsScopes
 import com.google.api.services.drive.DriveScopes
 import com.google.api.services.tasks.TasksScopes
 import com.neubofy.reality.R


### PR DESCRIPTION
Removed the unused `DocsScopes` import from `ProfileActivity` to clear automated scanner flags regarding the `googleapis.com/auth/documents` and `googleapis.com/auth/spreadsheets` scopes. The Docs and Sheets integration code remains fully functional via the `drive.file` scope as instructed.

---
*PR created automatically by Jules for task [17184343888466592497](https://jules.google.com/task/17184343888466592497) started by @pawanwashudev-official*