### PR TITLE
Increase app limits to 16 hours and use Hour/Minute selectors

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,8 +28,8 @@ android {
         applicationId = "com.neubofy.reality"
         minSdk = 26
         targetSdk = 36  // Android 16
-        versionCode = 30
-        versionName = "1.1.0"
+        versionCode = 31
+        versionName = "1.1.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         

--- a/app/src/main/java/com/neubofy/reality/ui/activity/UsageLimitActivity.kt
+++ b/app/src/main/java/com/neubofy/reality/ui/activity/UsageLimitActivity.kt
@@ -67,7 +67,14 @@ class UsageLimitActivity : BaseActivity() {
         val hours = usageData.limitInMinutes / 60
         val mins = usageData.limitInMinutes % 60
         binding.tvCurrentLimit.text = "${hours}h ${mins}m"
-        binding.sliderLimit.value = usageData.limitInMinutes.toFloat().coerceIn(0f, 480f) // Max 8 hours
+
+        binding.npHours.minValue = 0
+        binding.npHours.maxValue = 16
+        binding.npHours.value = hours.coerceIn(0, 16)
+
+        binding.npMinutes.minValue = 0
+        binding.npMinutes.maxValue = 59
+        binding.npMinutes.value = mins.coerceIn(0, 59)
         
         binding.switchEnable.setOnCheckedChangeListener { _, isChecked ->
             if (!isChecked && !StrictLockUtils.isModificationAllowed(this)) {
@@ -80,29 +87,25 @@ class UsageLimitActivity : BaseActivity() {
             saveData()
         }
         
-        binding.sliderLimit.addOnChangeListener { _, value, fromUser ->
-            if (fromUser) {
-                 if (!StrictLockUtils.isModificationAllowed(this)) {
-                     // If trying to increase limit (relax restriction) -> Allowed? 
-                     // Usually Strict Mode prevents relaxing. Increasing limit = relaxing.
-                     // But here value is limit. Increasing limit = More time allowed = Relaxing.
-                     // So check strict mode.
-                     // Wait, StrictLockUtils logic: strict mode prevents modifying schedules.
-                     // Here we treat it strictly.
-                     if (value > usageData.limitInMinutes) {
-                         // Relaxing
-                         Toast.makeText(this, "Increase limit locked by Strict Mode.", Toast.LENGTH_SHORT).show()
-                         binding.sliderLimit.value = usageData.limitInMinutes.toFloat()
-                         return@addOnChangeListener
-                     }
-                 }
-                 usageData.limitInMinutes = value.toInt()
-                 val h = usageData.limitInMinutes / 60
-                 val m = usageData.limitInMinutes % 60
-                 binding.tvCurrentLimit.text = "${h}h ${m}m"
-                 saveData()
+        val onValueChangeListener = android.widget.NumberPicker.OnValueChangeListener { _, _, _ ->
+            val value = (binding.npHours.value * 60) + binding.npMinutes.value
+            if (!StrictLockUtils.isModificationAllowed(this)) {
+                if (value > usageData.limitInMinutes) {
+                    Toast.makeText(this, "Increase limit locked by Strict Mode.", Toast.LENGTH_SHORT).show()
+                    binding.npHours.value = usageData.limitInMinutes / 60
+                    binding.npMinutes.value = usageData.limitInMinutes % 60
+                    return@OnValueChangeListener
+                }
             }
+            usageData.limitInMinutes = value
+            val h = usageData.limitInMinutes / 60
+            val m = usageData.limitInMinutes % 60
+            binding.tvCurrentLimit.text = "${h}h ${m}m"
+            saveData()
         }
+
+        binding.npHours.setOnValueChangedListener(onValueChangeListener)
+        binding.npMinutes.setOnValueChangedListener(onValueChangeListener)
     }
 
     private val scope = kotlinx.coroutines.MainScope()
@@ -173,34 +176,61 @@ class UsageLimitActivity : BaseActivity() {
          }
          
          val tvLimit = TextView(this).apply {
-             text = "Limit: ${item.limitMins} mins"
+             text = "Limit: ${item.limitMins / 60}h ${item.limitMins % 60}m"
              textSize = 18f
              setTextColor(android.graphics.Color.WHITE)
              gravity = android.view.Gravity.CENTER
          }
          
-         val seekBar = SeekBar(this).apply {
-             max = 300 // 5 hours
-             progress = item.limitMins
+         val pickerLayout = android.widget.LinearLayout(this).apply {
+             orientation = android.widget.LinearLayout.HORIZONTAL
+             gravity = android.view.Gravity.CENTER
          }
          
-         seekBar.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
-             override fun onProgressChanged(seekBar: SeekBar?, progress: Int, fromUser: Boolean) {
-                 val p = (progress / 5) * 5 // Step 5
-                 tvLimit.text = "Limit: $p mins"
-             }
-             override fun onStartTrackingTouch(seekBar: SeekBar?) {}
-             override fun onStopTrackingTouch(seekBar: SeekBar?) {}
-         })
+         val npHours = android.widget.NumberPicker(this).apply {
+             minValue = 0
+             maxValue = 16
+             value = item.limitMins / 60
+         }
+
+         val tvHours = TextView(this).apply {
+             text = " h "
+             textSize = 18f
+             setTextColor(android.graphics.Color.WHITE)
+         }
+
+         val npMinutes = android.widget.NumberPicker(this).apply {
+             minValue = 0
+             maxValue = 59
+             value = item.limitMins % 60
+         }
+
+         val tvMinutes = TextView(this).apply {
+             text = " m "
+             textSize = 18f
+             setTextColor(android.graphics.Color.WHITE)
+         }
+
+         pickerLayout.addView(npHours)
+         pickerLayout.addView(tvHours)
+         pickerLayout.addView(npMinutes)
+         pickerLayout.addView(tvMinutes)
+
+         val onValueChangeListener = android.widget.NumberPicker.OnValueChangeListener { _, _, _ ->
+             tvLimit.text = "Limit: ${npHours.value}h ${npMinutes.value}m"
+         }
+
+         npHours.setOnValueChangedListener(onValueChangeListener)
+         npMinutes.setOnValueChangedListener(onValueChangeListener)
          
          layout.addView(tvLimit)
-         layout.addView(seekBar)
+         layout.addView(pickerLayout)
          
          MaterialAlertDialogBuilder(this)
              .setTitle("Set Limit for ${item.appName}")
              .setView(layout)
              .setPositiveButton("Save") { _, _ ->
-                 val newLimit = (seekBar.progress / 5) * 5
+                 val newLimit = (npHours.value * 60) + npMinutes.value
                  if (newLimit < item.limitMins && item.limitMins > 0 && !StrictLockUtils.isModificationAllowed(this)) {
                       // Increasing restriction (lower limit) is ALLOWED.
                  }

--- a/app/src/main/java/com/neubofy/reality/ui/fragments/AppLimitsFragment.kt
+++ b/app/src/main/java/com/neubofy/reality/ui/fragments/AppLimitsFragment.kt
@@ -249,16 +249,21 @@ class AppLimitsFragment : Fragment() {
         }
         
         // Bind UI
-        dialogBinding.seekBarLimit.valueFrom = 0f
-        dialogBinding.seekBarLimit.valueTo = 480f
-        dialogBinding.seekBarLimit.stepSize = 15f
-        dialogBinding.seekBarLimit.value = currentLimit.toFloat()
+        dialogBinding.npHours.minValue = 0
+        dialogBinding.npHours.maxValue = 16
+        dialogBinding.npHours.value = currentLimit / 60
+
+        dialogBinding.npMinutes.minValue = 0
+        dialogBinding.npMinutes.maxValue = 59
+        dialogBinding.npMinutes.value = currentLimit % 60
+
         dialogBinding.tvLimitValue.text = "${currentLimit / 60}h ${currentLimit % 60}m"
         dialogBinding.cbStrict.isChecked = isStrict
         
         if (isLocked) {
             // Disable all UI elements when locked
-            dialogBinding.seekBarLimit.isEnabled = false
+            dialogBinding.npHours.isEnabled = false
+            dialogBinding.npMinutes.isEnabled = false
             dialogBinding.cbStrict.isEnabled = false
             dialogBinding.cbStrict.isClickable = false
             dialogBinding.btnAddPeriod.isEnabled = false
@@ -271,11 +276,14 @@ class AppLimitsFragment : Fragment() {
             }
         }
         
-        dialogBinding.seekBarLimit.addOnChangeListener { _, value, _ ->
-            currentLimit = value.toInt()
-            dialogBinding.tvLimitValue.text = "${currentLimit / 60}h ${currentLimit % 60}m"
+        val onValueChangeListener = android.widget.NumberPicker.OnValueChangeListener { _, _, _ ->
+            currentLimit = (dialogBinding.npHours.value * 60) + dialogBinding.npMinutes.value
+            dialogBinding.tvLimitValue.text = "${dialogBinding.npHours.value}h ${dialogBinding.npMinutes.value}m"
         }
         
+        dialogBinding.npHours.setOnValueChangedListener(onValueChangeListener)
+        dialogBinding.npMinutes.setOnValueChangedListener(onValueChangeListener)
+
         // Chips Logic
         fun refreshChips() {
             dialogBinding.chipGroupPeriods.removeAllViews()

--- a/app/src/main/java/com/neubofy/reality/ui/fragments/GroupsFragment.kt
+++ b/app/src/main/java/com/neubofy/reality/ui/fragments/GroupsFragment.kt
@@ -125,7 +125,13 @@ class GroupsFragment : Fragment() {
             dialogBinding.etGroupName.setText(group.name)
             
             val limit = group.limitInMinutes
-            dialogBinding.sliderLimit.progress = limit
+            dialogBinding.npHours.minValue = 0
+            dialogBinding.npHours.maxValue = 16
+            dialogBinding.npHours.value = limit / 60
+
+            dialogBinding.npMinutes.minValue = 0
+            dialogBinding.npMinutes.maxValue = 59
+            dialogBinding.npMinutes.value = limit % 60
             dialogBinding.tvLimitValue.text = "${limit / 60}h ${limit % 60}m"
             
             dialogBinding.cbStrict.isChecked = group.isStrict
@@ -160,21 +166,26 @@ class GroupsFragment : Fragment() {
             }
         } else {
              dialogBinding.tvLimitValue.text = "1h 30m"
-             dialogBinding.sliderLimit.progress = 90
+             dialogBinding.npHours.minValue = 0
+             dialogBinding.npHours.maxValue = 16
+             dialogBinding.npHours.value = 1
+
+             dialogBinding.npMinutes.minValue = 0
+             dialogBinding.npMinutes.maxValue = 59
+             dialogBinding.npMinutes.value = 30
         }
         
         updateActivePeriodText(dialogBinding, activePeriods)
 
         // Interactions
-        dialogBinding.sliderLimit.setOnSeekBarChangeListener(object: SeekBar.OnSeekBarChangeListener {
-            override fun onProgressChanged(seekBar: SeekBar?, progress: Int, fromUser: Boolean) {
-                val h = progress / 60
-                val m = progress % 60
-                dialogBinding.tvLimitValue.text = "${h}h ${m}m"
-            }
-            override fun onStartTrackingTouch(seekBar: SeekBar?) {}
-            override fun onStopTrackingTouch(seekBar: SeekBar?) {}
-        })
+        val onValueChangeListener = android.widget.NumberPicker.OnValueChangeListener { _, _, _ ->
+            val h = dialogBinding.npHours.value
+            val m = dialogBinding.npMinutes.value
+            dialogBinding.tvLimitValue.text = "${h}h ${m}m"
+        }
+
+        dialogBinding.npHours.setOnValueChangedListener(onValueChangeListener)
+        dialogBinding.npMinutes.setOnValueChangedListener(onValueChangeListener)
 
         dialogBinding.btnSelectApps.setOnClickListener {
             val intent = Intent(requireContext(), SelectAppsActivity::class.java)
@@ -198,7 +209,8 @@ class GroupsFragment : Fragment() {
         // Strict Mode Locking
         if (isLocked) {
              dialogBinding.etGroupName.isEnabled = false
-             dialogBinding.sliderLimit.isEnabled = false
+             dialogBinding.npHours.isEnabled = false
+             dialogBinding.npMinutes.isEnabled = false
              dialogBinding.cbStrict.isEnabled = false
              dialogBinding.cbStrict.isClickable = false
              dialogBinding.btnSelectApps.isEnabled = false
@@ -224,7 +236,7 @@ class GroupsFragment : Fragment() {
                 }
                 
                 val name = dialogBinding.etGroupName.text.toString()
-                val limit = dialogBinding.sliderLimit.progress
+                val limit = (dialogBinding.npHours.value * 60) + dialogBinding.npMinutes.value
                 val isStrict = dialogBinding.cbStrict.isChecked
                 
                 if (name.isBlank()) {

--- a/app/src/main/res/layout/activity_usage_limit.xml
+++ b/app/src/main/res/layout/activity_usage_limit.xml
@@ -151,14 +151,32 @@
                                     android:textColor="?attr/colorPrimary" />
                         </LinearLayout>
 
-                        <com.google.android.material.slider.Slider
-                            android:id="@+id/slider_limit"
+                        <LinearLayout
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:valueFrom="0"
-                            android:valueTo="300"
-                            android:stepSize="15"
-                            android:value="60" />
+                            android:gravity="center"
+                            android:orientation="horizontal">
+                            <NumberPicker
+                                android:id="@+id/np_hours"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content" />
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="h "
+                                android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
+                                android:textColor="?attr/colorPrimary" />
+                            <NumberPicker
+                                android:id="@+id/np_minutes"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content" />
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="m "
+                                android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
+                                android:textColor="?attr/colorPrimary" />
+                        </LinearLayout>
                     </LinearLayout>
                 </LinearLayout>
             </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/dialog_add_group.xml
+++ b/app/src/main/res/layout/dialog_add_group.xml
@@ -27,19 +27,33 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        android:gravity="center_vertical">
-        <SeekBar
-            android:id="@+id/sliderLimit"
-            android:layout_width="0dp"
+        android:gravity="center">
+        <NumberPicker
+            android:id="@+id/npHours"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+        <TextView
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:max="480"
-            android:progress="60"/>
+            android:text="h "
+            android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
+            android:textColor="?attr/colorPrimary" />
+        <NumberPicker
+            android:id="@+id/npMinutes"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="m "
+            android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
+            android:textColor="?attr/colorPrimary" />
         <TextView
             android:id="@+id/tvLimitValue"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="1h 0m"/>
+            android:text="1h 0m"
+            android:visibility="gone"/>
     </LinearLayout>
 
     <Button

--- a/app/src/main/res/layout/dialog_set_limit.xml
+++ b/app/src/main/res/layout/dialog_set_limit.xml
@@ -27,15 +27,33 @@
             android:textAppearance="@style/TextAppearance.Material3.DisplaySmall"
             android:textColor="?attr/colorPrimary"/>
 
-        <com.google.android.material.slider.Slider
-            android:id="@+id/seekBarLimit"
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
-            android:valueFrom="0"
-            android:valueTo="300"
-            android:stepSize="15"
-            android:value="60"/>
+            android:gravity="center"
+            android:orientation="horizontal">
+            <NumberPicker
+                android:id="@+id/npHours"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="h "
+                android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
+                android:textColor="?attr/colorPrimary" />
+            <NumberPicker
+                android:id="@+id/npMinutes"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="m "
+                android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
+                android:textColor="?attr/colorPrimary" />
+        </LinearLayout>
 
         <TextView
             android:layout_width="wrap_content"


### PR DESCRIPTION
The user requested to increase the app limit feature from an 8-hour maximum to a 16-hour maximum and change the input UI to a selector specifically for hours and minutes. I have replaced all slider-based selectors for global limits, app limits, and group limits with two NumberPickers (one for hours, 0-16, and one for minutes, 0-59). The internal calculations have been correctly updated to combine these values. I also bumped the `versionCode` and `versionName` as requested. Tests and builds pass without issue.

---
*PR created automatically by Jules for task [16918546018724359546](https://jules.google.com/task/16918546018724359546) started by @pawanwashudev-official*