### PR TITLE
docs: update AI architecture explanation to Cloudflare Workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Unlike apps that lock essential tools behind forced popups, **Reality is designe
 * **100% Source-Available**: Every line of code is open for public audit on GitHub. No hidden backend servers processing your data.
 * **Open-Source Infrastructure**: The AI worker runs on Cloudflare Workers, website, APK builds, and subscription management—all visible in this repository.
 * **Zero-Server Architecture**: Reality processes all data locally on your device. Your habits, journals, and calendar data never pass through Neubofy servers.
-* **Transparent AI with Cloudflare Speed**: Our Reality Intelligence Assistant uses open-source heavy models (**GPT-OSS 20B and 120B**) on your device for complete data privacy, while leveraging Cloudflare Worker edge servers for inference speed and performance optimization.
+* **Transparent AI with Cloudflare Workers**: Our Reality Intelligence Assistant uses open-source heavy models (**GPT-OSS 20B and 120B**) via Cloudflare Worker edge servers rather than locally on device. We also support bringing your own Gemini API key. This architecture provides complete privacy like a local model—no chats or data are stored—while ensuring zero load on your device and leveraging Cloudflare edge server speed.
 * **Bring Your Own Cloud (BYOC)**: You sync directly through your own Google Cloud OAuth credentials—zero developer involvement.
 
 * **Modular Feature Toggles**: By default, advanced integrations are kept disabled so the app stays clean and lightweight for everyday use.
@@ -108,9 +108,9 @@ A local-first assistant that executes practical in-app actions rather than just 
 * Runs in `AIChatActivity.kt` and `PopupAIChatActivity.kt`, configured via `AISettingsActivity.kt`.
 * Uses Model Context Protocol (MCP) tool registrations (`ToolRegistry.kt`) to adjust alarms, add tasks, and manage app blocks directly on your device.
 * **AI Architecture**: 
-  - **On-Device Models**: Runs open-source GPT-OSS 20B and 120B models locally on your device for complete data privacy
-  - **Cloudflare Edge Inference**: Leverages Cloudflare Worker edge servers for inference acceleration and speed optimization
-  - **Zero Data Collection**: Your conversations and AI interactions never leave your device or are stored on developer servers
+  - **Cloudflare Edge Models**: We do not provide the option to run AI models locally. Instead, open-source GPT-OSS 20B and 120B models are processed via Cloudflare Workers. You can also opt to use Gemini models directly by providing your own API key.
+  - **Zero Device Load & Edge Speed**: This architecture provides the speed of Cloudflare edge servers with zero processing load on your device.
+  - **Complete Privacy**: This setup gives complete privacy just like a local model. We do not store any chats or data, and zero personal information is logged on developer servers.
 
 ### 6. 🎨 Custom Appearance & Themes
 Tailor the look and feel of the app to match your setup in `AppearanceActivity.kt` with custom fonts, AMOLED dark palettes, and Material3 styling.
@@ -158,9 +158,9 @@ Threading:       Kotlin Coroutines + Flow
 Networking:      OkHttp + Retrofit
 Background:      WorkManager + AlarmManager
 Parsers:         GSON, JSoup, Markwon
-AI Models:       GPT-OSS 20B & 120B (On-Device)
+AI Models:       GPT-OSS 20B & 120B (Cloudflare Workers)
 Web Stack:       Next.js + React + TypeScript (Website & Tapashya Timer)
-Edge Inference:  Cloudflare Workers (JIT Cryptography & AI Acceleration)
+Edge Inference:  Cloudflare Workers (JIT Cryptography & AI Models)
 ```
 
 ### Key Libraries

--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -250,26 +250,26 @@ export default async function Home() {
          <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
             <div className="text-center mb-12">
                <h2 className="text-3xl font-extrabold text-white">Reality Intelligence Assistant</h2>
-               <p className="text-gray-400 mt-2">Open-Source AI with Transparent Edge Acceleration</p>
+               <p className="text-gray-400 mt-2">Open-Source AI with Transparent Edge Architecture</p>
             </div>
 
             <div className="bg-neural-card p-4 sm:p-8 rounded-2xl border border-gray-800 shadow-lg space-y-6">
                <div className="grid md:grid-cols-2 gap-8">
                   <div className="space-y-4">
                      <h3 className="text-xl font-bold text-neural-cyan flex items-center gap-2">
-                        <Brain size={24} /> On-Device Models
+                        <Brain size={24} /> Cloudflare AI Workers
                      </h3>
                      <p className="text-gray-300 text-sm leading-relaxed">
-                        Reality runs open-source GPT-OSS 20B and 120B models directly on your device. Your conversations, journal reflections, and task requests never leave your phone.
+                        We do not provide the option to run AI models locally. Instead, open-source GPT-OSS 20B and 120B models are processed via Cloudflare Workers. We also provide the option for users to use Gemini models by providing their own API key. Your conversations, journal reflections, and task requests are processed with complete privacy and we do not store any chats.
                      </p>
                      <ul className="space-y-2 text-gray-400 text-sm">
                         <li className="flex items-start gap-2">
                            <CheckCircle size={16} className="text-neural-cyan mt-0.5 shrink-0" />
-                           <span>Complete data privacy</span>
+                           <span>Complete data privacy, like local models</span>
                         </li>
                         <li className="flex items-start gap-2">
                            <CheckCircle size={16} className="text-neural-cyan mt-0.5 shrink-0" />
-                           <span>Works 100% offline</span>
+                           <span>Zero load on your device</span>
                         </li>
                         <li className="flex items-start gap-2">
                            <CheckCircle size={16} className="text-neural-cyan mt-0.5 shrink-0" />
@@ -280,15 +280,15 @@ export default async function Home() {
 
                   <div className="space-y-4">
                      <h3 className="text-xl font-bold text-neural-purple flex items-center gap-2">
-                        <Zap size={24} /> Cloudflare Edge Acceleration
+                        <Zap size={24} /> Cloudflare Edge Speed
                      </h3>
                      <p className="text-gray-300 text-sm leading-relaxed">
-                        For faster inference on complex tasks, Reality optionally leverages Cloudflare Workers for JIT cryptography and model acceleration. <strong>No data is stored or logged on edge servers.</strong>
+                        By relying on Cloudflare AI Workers, Reality provides inference speed on complex tasks, as well as JIT cryptography. <strong>No data is stored or logged on edge servers.</strong>
                      </p>
                      <ul className="space-y-2 text-gray-400 text-sm">
                         <li className="flex items-start gap-2">
                            <CheckCircle size={16} className="text-neural-purple mt-0.5 shrink-0" />
-                           <span>Speed optimization only</span>
+                           <span>Leveraging Edge server speed</span>
                         </li>
                         <li className="flex items-start gap-2">
                            <CheckCircle size={16} className="text-neural-purple mt-0.5 shrink-0" />
@@ -430,7 +430,7 @@ Once I have the keys, tell me to open the Reality App -> Go to the Elite Page or
           <li><strong>Database ORM:</strong> Room SQLite mapping schemas locally in the app namespace.</li>
           <li><strong>On-Device Encryption:</strong> Stored locally using Android Native EncryptedSharedPreferences.</li>
           <li><strong>Google APIs Integration:</strong> Uses Google OAuth client credentials of application type Desktop Application to directly write and sync metrics to the user's personal Google Cloud workspace.</li>
-          <li><strong>AI Models:</strong> Open-source GPT-OSS 20B and 120B models run on-device for complete privacy.</li>
+          <li><strong>AI Models:</strong> Open-source GPT-OSS 20B and 120B models run via Cloudflare Workers for zero device load and complete privacy (no chats or data are stored). Users can also bring their own Gemini API key for local API routing.</li>
           <li><strong>JIT Edge Cryptography:</strong> JIT encryption keys and identity parameters are generated using Cloudflare Workers edge nodes executing HMAC-SHA256 calculations locally with secret peppers.</li>
           <li><strong>Blocker Hook Loop:</strong> Leverages DeviceAdminReceiver to lock uninstalls and AccessibilityService callbacks to catch window package modifications, redirecting target distractions.</li>
           <li><strong>Assistant Engine:</strong> Runs using the Model Context Protocol (MCP) tool routing mapped to JVM registries.</li>


### PR DESCRIPTION
Updated the documentation to properly explain the AI architecture. It now correctly notes that the GPT-OSS 20B/120B models run via Cloudflare AI Workers, not locally on the device, while maintaining the same privacy guarantees (no chat storage). It also now explicitly mentions the option to use personal Gemini API keys.

---
*PR created automatically by Jules for task [1769175627738679895](https://jules.google.com/task/1769175627738679895) started by @pawanwashudev-official*