### PR TITLE
feat: add Zoho SalesIQ live chat widget

### DIFF
--- a/website/src/app/layout.tsx
+++ b/website/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Inter, Outfit } from "next/font/google";
 import Link from 'next/link';
 import Image from 'next/image';
+import Script from 'next/script';
 import { Crown } from 'lucide-react';
 import { Analytics } from '@vercel/analytics/next';
 import MobileNav from './MobileNav';
@@ -145,6 +146,18 @@ export default function RootLayout({
             </div>
         </footer>
         <Analytics />
+        <Script
+          id="zoho-salesiq-inline"
+          strategy="afterInteractive"
+          dangerouslySetInnerHTML={{
+            __html: `window.$zoho=window.$zoho || {};$zoho.salesiq=$zoho.salesiq||{ready:function(){}}`
+          }}
+        />
+        <Script
+          id="zsiqscript"
+          strategy="afterInteractive"
+          src="https://salesiq.zoho.in/widget?wc=siq9312488e4d8e0df500748f7a2fc1e8769385757ecd612b79f3d0afb943c616a1"
+        />
       </body>
     </html>
   );


### PR DESCRIPTION
This PR adds the Zoho SalesIQ live chat widget script to the root Next.js layout file `website/src/app/layout.tsx`. It incorporates both the initialization script and the external script provided. By adding it to the root layout using `next/script`, the widget is globally available across all application pages without blocking initial rendering.

---
*PR created automatically by Jules for task [10114098311582914900](https://jules.google.com/task/10114098311582914900) started by @pawanwashudev-official*